### PR TITLE
Update screenshot

### DIFF
--- a/templates/locales/pull_request_opened.md.erb
+++ b/templates/locales/pull_request_opened.md.erb
@@ -4,6 +4,6 @@ If you haven't done so yet, please make sure your locale file [validates](https:
 
 To update this pull request, visit the "Files changed" tab above, and click on the pencil icon (see below) in the top-right corner of your locale file to start editing.
 
-![image](https://cloud.githubusercontent.com/assets/77951/15399073/3869aa90-1db4-11e6-8a92-f64af26b13b5.png)
+<img width="274" src="https://user-images.githubusercontent.com/77951/34369455-bd50432c-eab3-11e7-945e-6a6147dfc507.png">
 
 If you have any questions, please leave a comment and we'll get back to you. While we usually respond in English, feel free to write in whatever language you're most comfortable.

--- a/templates/styles/pull_request_opened.md.erb
+++ b/templates/styles/pull_request_opened.md.erb
@@ -4,6 +4,6 @@ If you haven't done so yet, please make sure your style [validates](https://gith
 
 To update this pull request, visit the "Files changed" tab above, and click on the pencil icon (see below) in the top-right corner of your style to start editing.
 
-![image](https://cloud.githubusercontent.com/assets/77951/15399073/3869aa90-1db4-11e6-8a92-f64af26b13b5.png)
+<img width="274" src="https://user-images.githubusercontent.com/77951/34369455-bd50432c-eab3-11e7-945e-6a6147dfc507.png">
 
 If you have any questions, please leave a comment and we'll get back to you. While we usually respond in English, feel free to write in whatever language you're most comfortable.


### PR DESCRIPTION
Now retina, and up-to-date with current GitHub UI.

<img width="274" src="https://user-images.githubusercontent.com/77951/34369455-bd50432c-eab3-11e7-945e-6a6147dfc507.png">

(previous update in #5)